### PR TITLE
Fixed prefixed resource locations in codecs

### DIFF
--- a/src/main/java/de/budschie/bmorph/morph/functionality/codec_addition/ModCodecs.java
+++ b/src/main/java/de/budschie/bmorph/morph/functionality/codec_addition/ModCodecs.java
@@ -200,7 +200,7 @@ public class ModCodecs
 					
 					try
 					{
-						result = new ResourceLocation(rl.result().get());
+						result = new ResourceLocation(str);
 					}
 					catch(ResourceLocationException ex)
 					{


### PR DESCRIPTION
After testing it looks like it indeed fixes #132 